### PR TITLE
Behaviour compatibility with Zend Framework Expressive

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ module/Application/config/module.config.php
     // ...
     'services' => array(
         // ...
-        'my.third.middleware' => function($request, $response, $next) {
+        'my.third.middleware' => function($request, $response, $next = null) {
             // My code here. For instance:
 
             var_dump($request->getHeader('user-agent'));
-            return $next();
+            return $next($request, $response);
         },
         // ...
     ),
@@ -103,13 +103,13 @@ namespace Application\Middleware;
 
 class First
 {
-    public function __invoke($request, $response, $next)
+    public function __invoke($request, $response, $next = null)
     {
         // My code here. For instance:
 
         var_dump($request->getHeader('user-agent'));
 
-        $result = $next(); // call the next middleware
+        $result = $next($request, $response); // call the next middleware
 
         // Run code after all middlewares run
         return $result; // Return anything
@@ -125,13 +125,13 @@ namespace Application\Middleware;
 
 class Second
 {
-    public function __invoke($request, $response, $next)
+    public function __invoke($request, $response, $next = null)
     {
         // My code here. For instance:
 
         var_dump($request->getHeader('user-agent'));
         
-        $next(); // call the next middleware
+        $next($request, $response); // call the next middleware
 
         // Run code after all middlewares run
     }
@@ -141,10 +141,10 @@ class Second
 #### Return responses
 
 If your first middleware will return object that implements Zend\Stdlib\ResponseInterface, Controller will be never called.
-Of course, your previous Middlewares (if they exists) should return $next();
+Of course, your previous Middlewares (if they exists) should return $next($request, $response);
 
 ```php
-function __invoke($request, $response, $next)
+function __invoke($request, $response, $next = null)
 {
     return $response; // Do not call anything more and return this Response to the client
 }
@@ -219,7 +219,7 @@ If you don't want to declare middlewares inside your service manager config key,
     
     class First implements MiddlewareInterface
     {
-        public function __invoke(RequestInterface $request, ResponseInterface $response, callable $next)
+        public function __invoke(RequestInterface $request, ResponseInterface $response, callable $next = null)
         {
             // My code here.
         }
@@ -270,10 +270,10 @@ You can provide any callable as a middleware name. Such as functions, static met
         'my.first.middleware',
         'my.second.middleware',
         'MyNamespace\MyClass::MyStaticMethod', // Static method sample
-        function ($request, $response, $next) // Function sample
+        function ($request, $response, $next = null) // Function sample
         {
             var_dump($request->getHeader('user-agent'));
-            return $next();
+            return $next($request, $response);
         }
     ),
     'local' => array(
@@ -296,7 +296,7 @@ class MyOwnResponse implements ResponseInterface
 {
     // ...
 }
-function __invoke($request, $response, $next)
+function __invoke($request, $response, $next = null)
 {
     $newResponse = new MyOwnResponse();
     return $next($request, $newResponse, $next);

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ between route and controller dispatch phases.
 Installation
 ------------
 
+PHP 5.4 or higher is required.
+
 #### With composer
 
 Add this project in your `composer.json`:

--- a/src/Middleware/Listener/MiddlewareListener.php
+++ b/src/Middleware/Listener/MiddlewareListener.php
@@ -47,10 +47,12 @@ class MiddlewareListener extends AbstractListenerAggregate
      * On dispatch handles local and global middlewares.
      *
      * @param MvcEvent $event
+     * @return \Zend\Stdlib\ResponseInterface|mixed
      */
     public function onDispatch(MvcEvent $event)
     {
         $sm = $event->getApplication()->getServiceManager();
+        /** @var \Middleware\Service\MiddlewareRunnerService $service */
         $service = $sm->get('MiddlewareRunnerService');
         $config  = $sm->get('Config');
         $controllerClass = $event->getRouteMatch()->getParam('controller').'Controller';
@@ -59,6 +61,6 @@ class MiddlewareListener extends AbstractListenerAggregate
         $local  = isset($config[self::CONFIG][self::CONFIG_LOCAL][$controllerClass]) ? $config[self::CONFIG][self::CONFIG_LOCAL][$controllerClass] : array();
         $middlewareNames = array_merge($global, $local);
 
-        $service->run($middlewareNames);
+        return $service->run($middlewareNames);
     }
 }

--- a/src/Middleware/MiddlewareInterface.php
+++ b/src/Middleware/MiddlewareInterface.php
@@ -14,11 +14,10 @@
 
 namespace Middleware;
 
-use Closure;
-use Zend\Http\PhpEnvironment\Request;
-use Zend\Http\PhpEnvironment\Response;
+use Zend\Stdlib\RequestInterface;
+use Zend\Stdlib\ResponseInterface;
 
 interface MiddlewareInterface
 {
-    public function __invoke(Request $request, Response $response, Closure $next);
+    public function __invoke(RequestInterface $request, ResponseInterface $response, callable $next);
 }

--- a/src/Middleware/MiddlewareInterface.php
+++ b/src/Middleware/MiddlewareInterface.php
@@ -19,5 +19,5 @@ use Zend\Stdlib\ResponseInterface;
 
 interface MiddlewareInterface
 {
-    public function __invoke(RequestInterface $request, ResponseInterface $response, callable $next);
+    public function __invoke(RequestInterface $request, ResponseInterface $response, callable $next = null);
 }

--- a/src/Middleware/Service/MiddlewareRunnerService.php
+++ b/src/Middleware/Service/MiddlewareRunnerService.php
@@ -14,33 +14,32 @@
 
 namespace Middleware\Service;
 
-use Closure;
-use Zend\Http\PhpEnvironment\Request;
-use Zend\Http\Response;
+use Zend\Stdlib\RequestInterface;
+use Zend\Stdlib\ResponseInterface;
 
 class MiddlewareRunnerService
 {
     /**
-     * @var Request
+     * @var RequestInterface
      */
     protected $request;
 
     /**
-     * @var Response
+     * @var ResponseInterface
      */
     protected $response;
 
     /**
-     * @var Closure
+     * @var callable
      */
     protected $factory;
 
     /**
-     * @param Request  $request
-     * @param Response $response
-     * @param Closure  $middlewareFactory
+     * @param RequestInterface $request
+     * @param ResponseInterface $response
+     * @param callable $middlewareFactory
      */
-    public function __construct(Request $request, Response $response, Closure $middlewareFactory)
+    public function __construct(RequestInterface $request, ResponseInterface $response, callable $middlewareFactory)
     {
         $this->request  = $request;
         $this->response = $response;

--- a/src/Middleware/Service/MiddlewareRunnerService.php
+++ b/src/Middleware/Service/MiddlewareRunnerService.php
@@ -92,6 +92,10 @@ class MiddlewareRunnerService
     protected function getNext()
     {
         $middlewareName = array_shift($this->middlewareNames);
+        if (!$middlewareName) {
+
+            return;
+        }
 
         if (is_callable($middlewareName)) {
             $middleware = $middlewareName;
@@ -117,6 +121,10 @@ class MiddlewareRunnerService
             callable $next = null
         ) use ($service) {
             $middleware = $service->getNext();
+            if (!$middleware) {
+
+                return;
+            }
 
             // Allow Middleware to overwrite request and response
             if (null !== $request) {

--- a/src/Middleware/Service/MiddlewareRunnerService.php
+++ b/src/Middleware/Service/MiddlewareRunnerService.php
@@ -14,6 +14,7 @@
 
 namespace Middleware\Service;
 
+use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\Stdlib\RequestInterface;
 use Zend\Stdlib\ResponseInterface;
 
@@ -35,20 +36,26 @@ class MiddlewareRunnerService
     protected $factory;
 
     /**
+     * @var array
+     */
+    protected $middlewareNames;
+
+    /**
      * @param RequestInterface $request
      * @param ResponseInterface $response
      * @param callable $middlewareFactory
+     * @param ServiceLocatorInterface $serviceManager
      */
     public function __construct(RequestInterface $request, ResponseInterface $response, callable $middlewareFactory)
     {
-        $this->request  = $request;
+        $this->request = $request;
         $this->response = $response;
-        $this->factory  = $middlewareFactory;
+        $this->factory = $middlewareFactory;
     }
 
     /**
      * Runs the middleware list.
-     * 
+     *
      * @param array $middlewareNames
      */
     public function run(array $middlewareNames)
@@ -56,31 +63,71 @@ class MiddlewareRunnerService
         if (!$middlewareNames) {
             return;
         }
+        $this->middlewareNames = $middlewareNames;
+        $next = $this->getNextCallable();
+        return $next();
+    }
 
-        $middlewareName = array_shift($middlewareNames);
+    /**
+     * Return the current Request object (useful after all middlewares was executed)
+     * @return RequestInterface
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    /**
+     * Return the current Response object (useful after all middlewares was executed)
+     * @return ResponseInterface
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getNext()
+    {
+        $middlewareName = array_shift($this->middlewareNames);
 
         if (is_callable($middlewareName)) {
             $middleware = $middlewareName;
-        }
-        else {
+        } else {
             $middleware = call_user_func($this->factory, $middlewareName);
         }
 
-        call_user_func($middleware, $this->request, $this->response, $this->getNext($middlewareNames));
+        return $middleware;
     }
 
     /**
      * Calls the next middleware.
      *
-     * @param array $middlewareNames
-     *
-     * @return Closure
+     * @return callable
      */
-    protected function getNext($middlewareNames)
+    protected function getNextCallable()
     {
         $service = $this;
-        return function () use ($service, $middlewareNames) {
-            $service->run($middlewareNames);
+
+        return function (
+            RequestInterface $request = null,
+            ResponseInterface $response = null,
+            callable $next = null
+        ) use ($service) {
+            $middleware = $service->getNext();
+
+            // Allow Middleware to overwrite request and response
+            if (null !== $request) {
+                $service->request = $request;
+            }
+            if (null !== $response) {
+                $service->response = $response;
+            }
+
+            // Middleware can return values for other middlewares and own Response for dispatcher
+            return call_user_func($middleware, $service->request, $service->response, $service->getNextCallable());
         };
     }
 }

--- a/tests/MiddlewareTest/Service/MiddlewareRunnerServiceTest.php
+++ b/tests/MiddlewareTest/Service/MiddlewareRunnerServiceTest.php
@@ -81,10 +81,10 @@ class MiddlewareRunnerServiceTest extends \PHPUnit_Framework_TestCase
             function($request, $response, $next) use ($test) {
 
                 // In some of previous middlewares request and response must be overwritten
-                $test->assertInstanceOf(\Zend\Http\Request::class, $request);
-                $test->assertNotInstanceOf(\Zend\Http\PhpEnvironment\Request::class, $request);
-                $test->assertInstanceOf(\Zend\Http\Response::class, $response);
-                $test->assertNotInstanceOf(\Zend\Http\PhpEnvironment\Response::class, $response);
+                $test->assertInstanceOf('\Zend\Http\Request', $request);
+                $test->assertNotInstanceOf('\Zend\Http\PhpEnvironment\Request', $request);
+                $test->assertInstanceOf('\Zend\Http\Response', $response);
+                $test->assertNotInstanceOf('\Zend\Http\PhpEnvironment\Response', $response);
                 $next(
                     $request,
                     $response
@@ -94,10 +94,10 @@ class MiddlewareRunnerServiceTest extends \PHPUnit_Framework_TestCase
         ));
         $request = $service->getRequest();
         $response = $service->getResponse();
-        $this->assertInstanceOf(\Zend\Http\Request::class, $request);
-        $this->assertNotInstanceOf(\Zend\Http\PhpEnvironment\Request::class, $request);
-        $this->assertInstanceOf(\Zend\Http\Response::class, $response);
-        $this->assertNotInstanceOf(\Zend\Http\PhpEnvironment\Response::class, $response);
+        $this->assertInstanceOf('\Zend\Http\Request', $request);
+        $this->assertNotInstanceOf('\Zend\Http\PhpEnvironment\Request', $request);
+        $this->assertInstanceOf('\Zend\Http\Response', $response);
+        $this->assertNotInstanceOf('\Zend\Http\PhpEnvironment\Response', $response);
     }
 
     public function testMiddlewareCanReturnValue()
@@ -123,7 +123,7 @@ class MiddlewareRunnerServiceTest extends \PHPUnit_Framework_TestCase
             },
             'testMiddleware'
         ));
-        $this->assertInstanceOf(\Zend\Http\PhpEnvironment\Response::class, $response);
+        $this->assertInstanceOf('\Zend\Http\PhpEnvironment\Response', $response);
     }
 
     /**

--- a/tests/MiddlewareTest/Service/MiddlewareRunnerServiceTest.php
+++ b/tests/MiddlewareTest/Service/MiddlewareRunnerServiceTest.php
@@ -36,11 +36,13 @@ class MiddlewareRunnerServiceTest extends \PHPUnit_Framework_TestCase
 
         $service = $this->givenService(function() use(&$factoryCallCount) {
             $factoryCallCount++;
-            return function(){};
+            return function() {};
         });
 
         $service->run(array());
+        $this->assertEquals(0, $factoryCallCount);
 
+        $service->run(array(null));
         $this->assertEquals(0, $factoryCallCount);
     }
 

--- a/tests/MiddlewareTest/Service/MiddlewareRunnerServiceTest.php
+++ b/tests/MiddlewareTest/Service/MiddlewareRunnerServiceTest.php
@@ -18,11 +18,6 @@ use Middleware\Service\MiddlewareRunnerService;
 
 class MiddlewareRunnerServiceTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @var MiddlewareRunnerService
-     */
-    private $service;
-
     public function testInvokeShouldCallHandleMethodFromMiddleware()
     {
         $middleware      = $this->givenMiddlewareStub();
@@ -54,15 +49,18 @@ class MiddlewareRunnerServiceTest extends \PHPUnit_Framework_TestCase
         $called = 0;
 
         $middlewareMock = $this->givenMiddlewareStub();
+        $test = $this;
 
-        $service = $this->givenService(function () use(&$called, $middlewareMock){
+        $service = $this->givenService(function () use($test, &$called, $middlewareMock){
 
             $called++;
 
             if ($called ==  1) {
-                return function ($request, $response, $next) use (&$called) {
+                return function ($request, $response, $next) use ($test, &$called) {
                     if ($called < 3) {
-                        $next();
+
+                        // Owerwrite request and response for next middlewares
+                        $next($test->givenDifferentRequestStub(), $test->givenDifferentResponseStub());
                     }
                 };
             }
@@ -74,11 +72,58 @@ class MiddlewareRunnerServiceTest extends \PHPUnit_Framework_TestCase
 
         $service->run(array(
             function($request, $response, $next){
-                $next();
+                $next(
+                    $this->givenRequestStub(),
+                    $this->givenResponseStub()
+                );
             },
             'teste1',
-            'teste3'
+            function($request, $response, $next) use ($test) {
+
+                // In some of previous middlewares request and response must be overwritten
+                $test->assertInstanceOf(\Zend\Http\Request::class, $request);
+                $test->assertNotInstanceOf(\Zend\Http\PhpEnvironment\Request::class, $request);
+                $test->assertInstanceOf(\Zend\Http\Response::class, $response);
+                $test->assertNotInstanceOf(\Zend\Http\PhpEnvironment\Response::class, $response);
+                $next(
+                    $request,
+                    $response
+                );
+            },
+            'teste3',
         ));
+        $request = $service->getRequest();
+        $response = $service->getResponse();
+        $this->assertInstanceOf(\Zend\Http\Request::class, $request);
+        $this->assertNotInstanceOf(\Zend\Http\PhpEnvironment\Request::class, $request);
+        $this->assertInstanceOf(\Zend\Http\Response::class, $response);
+        $this->assertNotInstanceOf(\Zend\Http\PhpEnvironment\Response::class, $response);
+    }
+
+    public function testMiddlewareCanReturnValue()
+    {
+        $service = $this->givenService(function() {
+            return function() {
+            };
+        });
+        $response = $service->run(array(
+            function($request, $response, $next) {
+                return $next(
+                    $this->givenRequestStub(),
+                    $this->givenResponseStub()
+                );
+            },
+            function($request, $response, $next) {
+                return $next();
+            },
+            function($request, $response, $next) {
+                $next();
+                $response->setContent('OK');
+                return $response; // You
+            },
+            'testMiddleware'
+        ));
+        $this->assertInstanceOf(\Zend\Http\PhpEnvironment\Response::class, $response);
     }
 
     /**
@@ -106,11 +151,31 @@ class MiddlewareRunnerServiceTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @return \Zend\Http\Request|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function givenDifferentRequestStub()
+    {
+        $request = $this->getStub('Zend\Http\Request');
+
+        return $request;
+    }
+
+    /**
      * @return \Zend\Http\PhpEnvironment\Response|\PHPUnit_Framework_MockObject_MockObject
      */
     private function givenResponseStub()
     {
         $request = $this->getStub('Zend\Http\PhpEnvironment\Response');
+
+        return $request;
+    }
+
+    /**
+     * @return \Zend\Http\Response|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function givenDifferentResponseStub()
+    {
+        $request = $this->getStub('Zend\Http\Response');
 
         return $request;
     }


### PR DESCRIPTION
1. Use interfaces as type hinting, not objects. 
2. Allow Middleware to overwrite request, response and callback for next middlewares.
3. Middlewares now can return values for other middlewares or Request for EventManager.

Examples:

```
function __invoke(Request $request, Response $response, callback $next)
{
        $response->setStatusCode(404);
        $response->setContent('Sorry');
        return $response; // ZF Controller will not called after this
        // OR return $next(); // Classic variant
        // OR $next(); return; // void, next middleware responses will be ignored
        // OR return $next($request, $response);
        // OR return $next($request, $response, function( Request $request, Response $response, callback $next ) {} ); // Replace callable to your own
}
```

**Important Note**: Backward compatibility with PHP 5.3 can't be maintained after this merge because of [callable](http://php.net/manual/ru/language.types.callable.php)
